### PR TITLE
refactor: vote weight and snapshotDelegatedVotes position

### DIFF
--- a/contexts/delegates.tsx
+++ b/contexts/delegates.tsx
@@ -176,9 +176,8 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({ children }) => {
             onChain: fetchedPeriod?.onChainVotesPct || 0,
             offChain: fetchedPeriod?.offChainVotesPct || 0,
           },
-          votingWeight: item.stats?.[0]?.voteWeight || item?.voteWeight,
-          delegatedVotes:
-            item.delegatedVotes || item.stats?.[0]?.snapshotDelegatedVotes,
+          votingWeight: item.voteWeight,
+          delegatedVotes: item.delegatedVotes || item.snapshotDelegatedVotes,
           twitterHandle: item.twitterHandle,
           discourseHandle: item.discourseHandle,
           updatedAt: fetchedPeriod?.updatedAt,
@@ -236,9 +235,8 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({ children }) => {
             offChain: fetchedPeriod?.offChainVotesPct || 0,
           },
           discourseHandle: item.discourseHandle,
-          votingWeight: item.stats?.[0]?.voteWeight || item.voteWeight,
-          delegatedVotes:
-            item.delegatedVotes || item.stats?.[0]?.snapshotDelegatedVotes,
+          votingWeight: item.voteWeight,
+          delegatedVotes: item.delegatedVotes || item.snapshotDelegatedVotes,
           twitterHandle: item.twitterHandle,
           updatedAt: fetchedPeriod?.updatedAt,
           karmaScore: fetchedPeriod?.karmaScore || 0,
@@ -292,7 +290,7 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({ children }) => {
           onChain: fetchedPeriod?.onChainVotesPct || 0,
           offChain: fetchedPeriod?.offChainVotesPct || 0,
         },
-        votingWeight: fetchedPeriod?.voteWeight || fetchedDelegate.voteWeight,
+        votingWeight: fetchedDelegate.voteWeight,
         delegatedVotes:
           fetchedDelegate.delegatedVotes ||
           fetchedDelegate.snapshotDelegatedVotes,
@@ -368,9 +366,8 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({ children }) => {
             onChain: fetchedPeriod?.onChainVotesPct || 0,
             offChain: fetchedPeriod?.offChainVotesPct || 0,
           },
-          votingWeight: item.stats?.[0]?.voteWeight || item?.voteWeight,
-          delegatedVotes:
-            item.delegatedVotes || item.stats?.[0]?.snapshotDelegatedVotes,
+          votingWeight: item?.voteWeight,
+          delegatedVotes: item.delegatedVotes || item.snapshotDelegatedVotes,
           twitterHandle: item.twitterHandle,
           discourseHandle: item.discourseHandle,
           updatedAt: fetchedPeriod?.updatedAt || '-',

--- a/types/IDelegateFromAPI.ts
+++ b/types/IDelegateFromAPI.ts
@@ -43,9 +43,8 @@ export interface IDelegateFromAPI {
     proposalsDiscussed: number;
     proposalsInitiated: number;
     updatedAt: string;
-    snapshotDelegatedVotes?: number;
-    voteWeight?: number;
   }[];
+  snapshotDelegatedVotes?: number;
   workstreams?: {
     id: number;
     name: string;


### PR DESCRIPTION
### Changelog

 - [X] Changed `delegate.stat.voteWeight|snapshotDelegatedVotes` to `delegate` parent object

needs [#422](https://github.com/show-karma/backend-nestjs/pull/422) to be in production