### PR TITLE
fix: backspaced input/removed delegate not allowing to search

### DIFF
--- a/components/pages/token-holders/TokenHolderDelegations.tsx
+++ b/components/pages/token-holders/TokenHolderDelegations.tsx
@@ -74,10 +74,8 @@ export const TokenHolderDelegation: FC = () => {
           }
           return false;
         }
-      )
-      .required('Please enter a valid address or ENS name.'),
+      ),
   });
-  type FormData = yup.InferType<typeof schema>;
 
   const {
     handleSubmit,
@@ -86,7 +84,7 @@ export const TokenHolderDelegation: FC = () => {
     watch,
     clearErrors,
     formState: { errors },
-  } = useForm<FormData>({
+  } = useForm({
     resolver: yupResolver(schema),
     reValidateMode: 'onChange',
     mode: 'onChange',
@@ -131,6 +129,7 @@ export const TokenHolderDelegation: FC = () => {
   };
 
   const getAddressesToAText = () => {
+    if (!selectedAddresses) return '';
     const addrs = selectedAddresses.map(addr =>
       addressRegex.test(addr) ? truncateAddress(addr) : addr
     );

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@chakra-ui/react": "^2.4.9",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@hookform/resolvers": "^3.0.0",
+    "@hookform/resolvers": "^3.1.1",
     "@polkadot/api": "^10.9.1",
     "@rainbow-me/rainbowkit": "^1.0.2",
     "@sentry/nextjs": "^7.23.0",
@@ -59,7 +59,7 @@
     "universal-cookie": "^4.0.4",
     "viem": "^0.3.31",
     "wagmi": "^1.2.0",
-    "yup": "^1.0.2"
+    "yup": "^1.2.0"
   },
   "devDependencies": {
     "@types/dompurify": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,7 +1543,7 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hookform/resolvers@^3.0.0":
+"@hookform/resolvers@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.1.1.tgz#b374d33e356428fff9c6ef3c933441fe15e40784"
   integrity sha512-tS16bAUkqjITNSvbJuO1x7MXbn7Oe8ZziDTJdA9mMvsoYthnOOiznOTGBYwbdlYBgU+tgpI/BtTU3paRbCuSlg==
@@ -8737,7 +8737,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^1.0.2:
+yup@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
   integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==


### PR DESCRIPTION
In delegate app for any DAO, go to delegate lookup page

Steps to reproduce: 
- [x] Add two addresses and click lookup, it works
- [x] Now remove one of them and click lookup - it says invalid address
- [x] Add one more and click lookup - says invalid address