### PR TITLE
fix: changed reserved => delegated, underlined title

### DIFF
--- a/components/BalanceOverview/index.tsx
+++ b/components/BalanceOverview/index.tsx
@@ -49,7 +49,7 @@ export const BalanceOverviewDisplay: React.FC<IBalanceOverviewDisplay> = ({
             </td>
           </tr>
           <tr>
-            <td>Reserved:</td>
+            <td>Delegated:</td>
             <td>
               <b>{Number(data.reserved).toFixed(8)}</b>
             </td>

--- a/components/Modals/Delegate/TrackDelegation.tsx
+++ b/components/Modals/Delegate/TrackDelegation.tsx
@@ -358,8 +358,10 @@ export const TrackDelegation: React.FC<StepProps> = ({
                   bg={theme.collapse.bg || theme.card.background}
                   color={theme.collapse.text}
                 >
-                  <small style={{ cursor: 'help' }}>
-                    View token balance breakdown
+                  <small
+                    style={{ cursor: 'help', textDecoration: 'underline' }}
+                  >
+                    <u>View token balance breakdown</u>
                   </small>
                 </Tooltip>
               )}

--- a/components/pages/token-holders/UndelegateModal.tsx
+++ b/components/pages/token-holders/UndelegateModal.tsx
@@ -302,7 +302,9 @@ export const UndelegateModal: React.FC<IUndelegateModalProps> = ({
                       bg={theme.collapse.bg || theme.card.background}
                       color={theme.collapse.text}
                     >
-                      <small style={{ cursor: 'help' }}>
+                      <small
+                        style={{ cursor: 'help', textDecoration: 'underline' }}
+                      >
                         View token balance breakdown
                       </small>
                     </Tooltip>


### PR DESCRIPTION
### Changelog

 - [X] Changed word `reserved` => `delegated` on Overview modal
 - [X] Underline on `view tokan balance breakdown`