### PR TITLE
feat: add penality points to finalScore modal

### DIFF
--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -249,7 +249,7 @@ export const DelegateFinalScoreModal = ({
     votingPowerMultiplier,
     delegateFeedback: delegateFeedbackScore,
     bonusPoint,
-    penaltyPoints: `-${securityCouncilVotePenalty}`,
+    penaltyPoints: securityCouncilVotePenalty,
   };
 
   return (

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -31,6 +31,7 @@ const statsLabel = {
   bonusPoint: 'Bonus Point (BP)',
   votingPowerMultiplier: 'Voting Power Multiplier (VP)',
   delegateFeedback: 'Delegate Feedback (DF)',
+  penaltyPoints: 'Penalty Points (PP)',
 };
 
 const statsFormula = (delegateStats: DelegateInfoStats) => ({
@@ -169,6 +170,16 @@ const statsFormula = (delegateStats: DelegateInfoStats) => ({
       </Code>
     </Flex>
   ),
+  penaltyPoints: (
+    <Flex flexDir="column" py="1" gap="2">
+      <Text fontWeight={600}>Penalty Points (PP) - Penalty for delayed votes</Text>
+      <Text fontWeight="normal">
+        Penalty points applied when a delegate delays their vote on Security
+        Council proposals, calculated based on the time between proposal creation
+        and their vote.
+      </Text>
+    </Flex>
+  ),
 });
 
 export const InfoTooltip = ({
@@ -182,7 +193,8 @@ export const InfoTooltip = ({
     | 'bonusPoint'
     | 'votingPowerMultiplier'
     | 'votingPowerAverage'
-    | 'delegateFeedback';
+    | 'delegateFeedback'
+    | 'penaltyPoints';
   stats: DelegateInfoStats;
 }) => {
   const { theme } = useDAO();
@@ -227,6 +239,7 @@ export const DelegateFinalScoreModal = ({
     votingPowerMultiplier = '0',
     delegateFeedback: { finalScore: delegateFeedbackScore = '0' } = {},
     bonusPoint = '0',
+    securityCouncilVotePenalty = '0',
   } = delegateStats || {};
 
   const stats = {
@@ -236,6 +249,7 @@ export const DelegateFinalScoreModal = ({
     votingPowerMultiplier,
     delegateFeedback: delegateFeedbackScore,
     bonusPoint,
+    penaltyPoints: `-${securityCouncilVotePenalty}`,
   };
 
   return (
@@ -366,8 +380,8 @@ export const DelegateFinalScoreModal = ({
                             </Text>
 
                             <Code fontWeight="normal">
-                              TP% formula: (PR + SV + TV) * VP Multiplier + DF +
-                              BP
+                              TP% formula: ((PR + SV + TV) * VP Multiplier + DF +
+                              BP) - PP
                             </Code>
                           </Flex>
                         }

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -172,11 +172,13 @@ const statsFormula = (delegateStats: DelegateInfoStats) => ({
   ),
   penaltyPoints: (
     <Flex flexDir="column" py="1" gap="2">
-      <Text fontWeight={600}>Penalty Points (PP) - Penalty for delayed votes</Text>
+      <Text fontWeight={600}>
+        Penalty Points (PP) - Penalty for delayed votes
+      </Text>
       <Text fontWeight="normal">
         Penalty points applied when a delegate delays their vote on Security
-        Council proposals, calculated based on the time between proposal creation
-        and their vote.
+        Council proposals, calculated based on the time between proposal
+        creation and their vote.
       </Text>
     </Flex>
   ),
@@ -380,8 +382,8 @@ export const DelegateFinalScoreModal = ({
                             </Text>
 
                             <Code fontWeight="normal">
-                              TP% formula: ((PR + SV + TV) * VP Multiplier + DF +
-                              BP) - PP
+                              TP% formula: ((PR + SV + TV) * VP Multiplier + DF
+                              + BP) - PP
                             </Code>
                           </Flex>
                         }

--- a/types/delegate-compensation/data.ts
+++ b/types/delegate-compensation/data.ts
@@ -26,6 +26,7 @@ export type DelegateInfoStats = {
   votingPowerAverage?: string;
   votingPowerMultiplier?: number;
   bonusPoint: number;
+  securityCouncilVotePenalty: string;
   commentingProposal: CompensationStatBreakdown;
   communicatingRationale: CompensationStatBreakdown;
   onChainVoting: CompensationStatBreakdown;
@@ -96,5 +97,6 @@ export type DelegateCompensationStats = {
   };
   bonusPoint: string;
   totalParticipation: string;
+  securityCouncilVotePenalty: string;
   payment: string;
 };

--- a/types/delegate-compensation/data.ts
+++ b/types/delegate-compensation/data.ts
@@ -26,7 +26,7 @@ export type DelegateInfoStats = {
   votingPowerAverage?: string;
   votingPowerMultiplier?: number;
   bonusPoint: number;
-  securityCouncilVotePenalty: string;
+  securityCouncilVotePenalty?: string;
   commentingProposal: CompensationStatBreakdown;
   communicatingRationale: CompensationStatBreakdown;
   onChainVoting: CompensationStatBreakdown;
@@ -97,6 +97,6 @@ export type DelegateCompensationStats = {
   };
   bonusPoint: string;
   totalParticipation: string;
-  securityCouncilVotePenalty: string;
+  securityCouncilVotePenalty?: string;
   payment: string;
 };


### PR DESCRIPTION

# Add Penalty Points to Delegate Final Score Calculation

This PR introduces penalty points for delayed votes on Security Council proposals to the delegate compensation system.

## Changes
- Added "Penalty Points (PP)" component to the final score modal
- Updated total participation formula to subtract penalty points
- Extended delegate stats types to include security council vote penalties 
- Added descriptive tooltips explaining the penalty mechanism

Penalty points are applied when delegates delay voting on Security Council proposals, calculated based on the time between the proposal creation and their vote submission.


![image](https://github.com/user-attachments/assets/acd1acb2-e4a1-4840-b64f-8a67d529526a)
![image](https://github.com/user-attachments/assets/4ecf325f-08a9-4acd-86c8-5f0e463cae3b)
