### PR TITLE
Feat/add penality points

### DIFF
--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -249,7 +249,7 @@ export const DelegateFinalScoreModal = ({
     votingPowerMultiplier,
     delegateFeedback: delegateFeedbackScore,
     bonusPoint,
-    penaltyPoints: `-${securityCouncilVotePenalty}`,
+    penaltyPoints: securityCouncilVotePenalty,
   };
 
   return (

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -178,6 +178,16 @@ const statsFormula = (delegateStats: DelegateInfoStats) => ({
         Council proposals, calculated based on the time between proposal creation
         and their vote.
       </Text>
+      {delegateStats?.securityPenaltyBreakdown && (
+        <>
+        <Code fontWeight="normal">
+          PP Formula: (MaxPenalty - MinPenalty) / (LastDay - FirstDay) = points per day
+        </Code>
+        <Code fontWeight="normal">
+          PP: {delegateStats.securityPenaltyBreakdown}
+        </Code>
+        </>
+      )}
     </Flex>
   ),
 });

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -172,20 +172,23 @@ const statsFormula = (delegateStats: DelegateInfoStats) => ({
   ),
   penaltyPoints: (
     <Flex flexDir="column" py="1" gap="2">
-      <Text fontWeight={600}>Penalty Points (PP) - Penalty for delayed votes</Text>
+      <Text fontWeight={600}>
+        Penalty Points (PP) - Penalty for delayed votes
+      </Text>
       <Text fontWeight="normal">
         Penalty points applied when a delegate delays their vote on Security
-        Council proposals, calculated based on the time between proposal creation
-        and their vote.
+        Council proposals, calculated based on the time between proposal
+        creation and their vote.
       </Text>
       {delegateStats?.securityPenaltyBreakdown && (
         <>
-        <Code fontWeight="normal">
-          PP Formula: (MaxPenalty - MinPenalty) / (LastDay - FirstDay) = points per day
-        </Code>
-        <Code fontWeight="normal">
-          PP: {delegateStats.securityPenaltyBreakdown}
-        </Code>
+          <Code fontWeight="normal">
+            PP Formula: (MaxPenalty - MinPenalty) / (LastDay - FirstDay) =
+            points per day
+          </Code>
+          <Code fontWeight="normal">
+            PP: {delegateStats.securityPenaltyBreakdown}
+          </Code>
         </>
       )}
     </Flex>
@@ -251,7 +254,6 @@ export const DelegateFinalScoreModal = ({
     bonusPoint = '0',
     securityCouncilVotePenalty = '0',
   } = delegateStats || {};
-
   const stats = {
     participationRate,
     snapshotVoting: snapshotScore,
@@ -390,8 +392,8 @@ export const DelegateFinalScoreModal = ({
                             </Text>
 
                             <Code fontWeight="normal">
-                              TP% formula: ((PR + SV + TV) * VP Multiplier + DF +
-                              BP) - PP
+                              TP% formula: ((PR + SV + TV) * VP Multiplier + DF
+                              + BP) - PP
                             </Code>
                           </Flex>
                         }

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateFinalScore.tsx
@@ -31,6 +31,7 @@ const statsLabel = {
   bonusPoint: 'Bonus Point (BP)',
   votingPowerMultiplier: 'Voting Power Multiplier (VP)',
   delegateFeedback: 'Delegate Feedback (DF)',
+  penaltyPoints: 'Penalty Points (PP)',
 };
 
 const statsFormula = (delegateStats: DelegateInfoStats) => ({
@@ -169,6 +170,16 @@ const statsFormula = (delegateStats: DelegateInfoStats) => ({
       </Code>
     </Flex>
   ),
+  penaltyPoints: (
+    <Flex flexDir="column" py="1" gap="2">
+      <Text fontWeight={600}>Penalty Points (PP) - Penalty for delayed votes</Text>
+      <Text fontWeight="normal">
+        Penalty points applied when a delegate delays their vote on Security
+        Council proposals, calculated based on the time between proposal creation
+        and their vote.
+      </Text>
+    </Flex>
+  ),
 });
 
 export const InfoTooltip = ({
@@ -182,7 +193,8 @@ export const InfoTooltip = ({
     | 'bonusPoint'
     | 'votingPowerMultiplier'
     | 'votingPowerAverage'
-    | 'delegateFeedback';
+    | 'delegateFeedback'
+    | 'penaltyPoints';
   stats: DelegateInfoStats;
 }) => {
   const { theme } = useDAO();
@@ -227,6 +239,7 @@ export const DelegateFinalScoreModal = ({
     votingPowerMultiplier = '0',
     delegateFeedback: { finalScore: delegateFeedbackScore = '0' } = {},
     bonusPoint = '0',
+    securityCouncilVotePenalty = '0',
   } = delegateStats || {};
 
   const stats = {
@@ -236,6 +249,7 @@ export const DelegateFinalScoreModal = ({
     votingPowerMultiplier,
     delegateFeedback: delegateFeedbackScore,
     bonusPoint,
+    penaltyPoints: `-${securityCouncilVotePenalty}`,
   };
 
   return (
@@ -366,8 +380,8 @@ export const DelegateFinalScoreModal = ({
                             </Text>
 
                             <Code fontWeight="normal">
-                              TP% formula: (PR + SV + TV) * VP Multiplier + DF +
-                              BP
+                              TP% formula: ((PR + SV + TV) * VP Multiplier + DF +
+                              BP) - PP
                             </Code>
                           </Flex>
                         }

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateStats.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateStats.tsx
@@ -485,7 +485,11 @@ export const DelegateStats = () => {
         >
           <Flex
             borderRadius="4px"
-            bg={delegateInfo?.stats?.securityPenaltyBreakdown ? "green.500" : "red.500"}
+            bg={
+              delegateInfo?.stats?.securityPenaltyBreakdown
+                ? 'green.500'
+                : 'red.500'
+            }
             w="40px"
             h="40px"
             justify="center"
@@ -493,7 +497,7 @@ export const DelegateStats = () => {
             color="white"
             fontWeight="bold"
           >
-            {delegateInfo?.stats?.securityPenaltyBreakdown ? "✓" : "✗"}
+            {delegateInfo?.stats?.securityPenaltyBreakdown ? '✓' : '✗'}
           </Flex>
           {delegateInfo?.stats?.securityPenaltyBreakdown ? (
             <Flex flexDir="column" gap="0" justify="center" align="flex-start">
@@ -517,7 +521,9 @@ export const DelegateStats = () => {
                   fontWeight={700}
                   color={theme.compensation?.card.secondaryText}
                 >
-                  {formatSimpleNumber(delegateInfo?.stats?.securityCouncilVotePenalty || 0)}
+                  {formatSimpleNumber(
+                    delegateInfo?.stats?.securityCouncilVotePenalty || 0
+                  )}
                 </Text>
                 <InfoTooltip
                   stat="penaltyPoints"
@@ -532,7 +538,7 @@ export const DelegateStats = () => {
                 fontWeight={400}
                 color={theme.compensation?.card.text}
               >
-                Didn't vote on SC Elections
+                {`Didn't vote on SC Elections`}
               </Text>
               <Text
                 fontSize="14px"

--- a/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateStats.tsx
+++ b/components/pages/delegate-compensation/v1.6/Admin/Delegates/DelegateStats.tsx
@@ -472,6 +472,80 @@ export const DelegateStats = () => {
           <DelegateBP isMonthFinished={isMonthFinished} />
         </Flex>
 
+        {/* Penalty Points Card */}
+        <Flex
+          flexDir="row"
+          bg={theme.compensation?.card.bg}
+          flex="1"
+          borderRadius="8px"
+          p="3"
+          gap="3"
+          justify="flex-start"
+          align="flex-start"
+        >
+          <Flex
+            borderRadius="4px"
+            bg={delegateInfo?.stats?.securityPenaltyBreakdown ? "green.500" : "red.500"}
+            w="40px"
+            h="40px"
+            justify="center"
+            align="center"
+            color="white"
+            fontWeight="bold"
+          >
+            {delegateInfo?.stats?.securityPenaltyBreakdown ? "✓" : "✗"}
+          </Flex>
+          {delegateInfo?.stats?.securityPenaltyBreakdown ? (
+            <Flex flexDir="column" gap="0" justify="center" align="flex-start">
+              <Text
+                fontSize="14px"
+                fontWeight={400}
+                color={theme.compensation?.card.text}
+              >
+                Voted on SC Elections
+              </Text>
+              <Flex flexDir="row" gap="2" align="center" mt="2">
+                <Text
+                  fontSize="14px"
+                  fontWeight={600}
+                  color={theme.compensation?.card.text}
+                >
+                  Penalty Points
+                </Text>
+                <Text
+                  fontSize="14px"
+                  fontWeight={700}
+                  color={theme.compensation?.card.secondaryText}
+                >
+                  {formatSimpleNumber(delegateInfo?.stats?.securityCouncilVotePenalty || 0)}
+                </Text>
+                <InfoTooltip
+                  stat="penaltyPoints"
+                  stats={delegateInfo?.stats as DelegateStatsFromAPI['stats']}
+                />
+              </Flex>
+            </Flex>
+          ) : (
+            <Flex flexDir="column" gap="0" justify="center" align="flex-start">
+              <Text
+                fontSize="14px"
+                fontWeight={400}
+                color={theme.compensation?.card.text}
+              >
+                Didn't vote on SC Elections
+              </Text>
+              <Text
+                fontSize="14px"
+                fontWeight={400}
+                color={theme.compensation?.card.secondaryText}
+                mt="2"
+              >
+                Disqualified of April and May Incentives
+              </Text>
+            </Flex>
+          )}
+        </Flex>
+
         <Flex
           flexDir="row"
           bg={theme.compensation?.card.bg}

--- a/types/delegate-compensation/data.ts
+++ b/types/delegate-compensation/data.ts
@@ -98,7 +98,7 @@ export type DelegateCompensationStats = {
   };
   bonusPoint: string;
   totalParticipation: string;
-  securityCouncilVotePenalty: string;
+  securityCouncilVotePenalty?: string;
   securityPenaltyBreakdown?: string;
   payment: string;
 };

--- a/types/delegate-compensation/data.ts
+++ b/types/delegate-compensation/data.ts
@@ -27,6 +27,7 @@ export type DelegateInfoStats = {
   votingPowerMultiplier?: number;
   bonusPoint: number;
   securityCouncilVotePenalty: string;
+  securityPenaltyBreakdown?: string;
   commentingProposal: CompensationStatBreakdown;
   communicatingRationale: CompensationStatBreakdown;
   onChainVoting: CompensationStatBreakdown;
@@ -98,5 +99,6 @@ export type DelegateCompensationStats = {
   bonusPoint: string;
   totalParticipation: string;
   securityCouncilVotePenalty: string;
+  securityPenaltyBreakdown?: string;
   payment: string;
 };

--- a/types/delegate-compensation/data.ts
+++ b/types/delegate-compensation/data.ts
@@ -26,6 +26,7 @@ export type DelegateInfoStats = {
   votingPowerAverage?: string;
   votingPowerMultiplier?: number;
   bonusPoint: number;
+  securityCouncilVotePenalty: string;
   commentingProposal: CompensationStatBreakdown;
   communicatingRationale: CompensationStatBreakdown;
   onChainVoting: CompensationStatBreakdown;
@@ -96,5 +97,6 @@ export type DelegateCompensationStats = {
   };
   bonusPoint: string;
   totalParticipation: string;
+  securityCouncilVotePenalty: string;
   payment: string;
 };


### PR DESCRIPTION

# Add Penalty Points to Delegate Compensation System

This PR introduces a new Penalty Points (PP) component to the delegate compensation system, which applies penalties for delayed or missed votes on Security Council proposals.

## Changes

- Added a new "Penalty Points" card between Bonus Points and Average Voting Power
- Implemented conditional display logic showing:
  - Green checkmark + penalty details for delegates who voted on SC elections
  - Red X + disqualification notice for delegates who didn't vote
- Updated the final score calculation formula to subtract penalty points: `((PR + SV + TV) * VP Multiplier + DF + BP) - PP`
- Added detailed tooltips explaining the penalty point system and formula
- Extended delegate stats types to include `securityCouncilVotePenalty` and `securityPenaltyBreakdown`

## Implementation Details

Penalty points are calculated based on the time between when a Security Council proposal is created and when a delegate submits their vote. The formula `(MaxPenalty - MinPenalty) / (LastDay - FirstDay)` determines points per day, with higher penalties for longer delays.

Delegates who didn't participate in Security Council elections are clearly marked as disqualified from April and May incentives.


![image](https://github.com/user-attachments/assets/e567d7dd-118f-4a7b-b448-17a5236e98c5)
![image](https://github.com/user-attachments/assets/800815c9-e849-4d12-a0f6-48bfced141eb)
![image](https://github.com/user-attachments/assets/206ae4a4-dd09-4081-a10b-0dbc522fe894)
