### PR TITLE
fix: Vp in snapshotDelegation Dao

### DIFF
--- a/contexts/delegates.tsx
+++ b/contexts/delegates.tsx
@@ -439,7 +439,10 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({
             offChain: fetchedPeriod?.offChainVotesPct || 0,
           },
           votingWeight: item.voteWeight,
-          delegatedVotes: +item.delegatedVotes || item.snapshotDelegatedVotes,
+          delegatedVotes:
+            +item.delegatedVotes > 0
+              ? +item.delegatedVotes
+              : +(item.snapshotDelegatedVotes || 0),
           gitcoinHealthScore: fetchedPeriod?.gitcoinHealthScore || 0,
           updatedAt: fetchedPeriod?.updatedAt,
           karmaScore: fetchedPeriod?.karmaScore || 0,
@@ -584,8 +587,9 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({
         },
         votingWeight: fetchedDelegate.voteWeight,
         delegatedVotes:
-          fetchedDelegate.delegatedVotes ||
-          fetchedDelegate.snapshotDelegatedVotes,
+          +fetchedDelegate.delegatedVotes > 0
+            ? +fetchedDelegate.delegatedVotes
+            : +(fetchedDelegate.snapshotDelegatedVotes || 0),
         gitcoinHealthScore: fetchedPeriod?.gitcoinHealthScore || 0,
         twitterHandle: fetchedDelegate.twitterHandle,
         discourseHandles: fetchedDelegate.discourseHandles,
@@ -645,8 +649,9 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({
         },
         votingWeight: fetchedDelegate.voteWeight,
         delegatedVotes:
-          fetchedDelegate.delegatedVotes ||
-          fetchedDelegate.snapshotDelegatedVotes,
+          +fetchedDelegate.delegatedVotes > 0
+            ? +fetchedDelegate.delegatedVotes
+            : +(fetchedDelegate.snapshotDelegatedVotes || 0),
         gitcoinHealthScore: fetchedPeriod?.gitcoinHealthScore || 0,
         twitterHandle: fetchedDelegate.twitterHandle,
         discourseHandles: fetchedDelegate.discourseHandles,
@@ -734,8 +739,9 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({
         },
         votingWeight: fetchedDelegate.voteWeight,
         delegatedVotes:
-          fetchedDelegate.delegatedVotes ||
-          fetchedDelegate.snapshotDelegatedVotes,
+          +fetchedDelegate.delegatedVotes > 0
+            ? +fetchedDelegate.delegatedVotes
+            : +(fetchedDelegate.snapshotDelegatedVotes || 0),
         gitcoinHealthScore: fetchedPeriod?.gitcoinHealthScore || 0,
         twitterHandle: fetchedDelegate.twitterHandle,
         discourseHandles: fetchedDelegate.discourseHandles,
@@ -822,7 +828,10 @@ export const DelegatesProvider: React.FC<ProviderProps> = ({
             offChain: fetchedPeriod?.offChainVotesPct || 0,
           },
           votingWeight: item?.voteWeight,
-          delegatedVotes: +item.delegatedVotes || item.snapshotDelegatedVotes,
+          delegatedVotes:
+            +item.delegatedVotes > 0
+              ? +item.delegatedVotes
+              : +(item.snapshotDelegatedVotes || 0),
           twitterHandle: item.twitterHandle,
           discourseHandles: item.discourseHandles,
           discordHandle: item.discordHandle,


### PR DESCRIPTION
**Fix: Display correct delegated votes when delegatedVotes is "0" but snapshotDelegatedVotes has value**
**Problem**

Profile pages showed "0" delegated tokens for delegates with Snapshot delegation but no on-chain delegation.

**Root Cause**
String "0" is truthy in JavaScript, so fetchedDelegate.delegatedVotes || fetchedDelegate.snapshotDelegatedVotes always returned "0" instead of falling back to snapshotDelegatedVotes.

**Solution**
Changed logic from truthy/falsy to numeric comparison:

