### PR TITLE
Fix: score breakdown title

### DIFF
--- a/components/DelegatesList.tsx
+++ b/components/DelegatesList.tsx
@@ -214,7 +214,7 @@ export const DelegatesList: FC<IDelegatesList> = ({ pathUser }) => {
       {selectedBreakdownUser && !!selectedBreakdownUser.address && (
         <StyledModal
           isOpen={isOpen}
-          title={`Forum Score Breakdown ${
+          title={`Score Breakdown ${
             formatPeriod(selectedBreakdownUser.period)
               ? ` (Last ${formatPeriod(selectedBreakdownUser.period)})`
               : ''


### PR DESCRIPTION
- [X] Remove "Forum" from "Score Breakdown" title.
![image](https://github.com/user-attachments/assets/4b489601-9812-4728-b2bf-c9948e5d613b)
![image](https://github.com/user-attachments/assets/84cbb8c4-69f6-4f6d-9376-1525d4ea93fa)
